### PR TITLE
It affects the functionality of callback

### DIFF
--- a/R/optparse.R
+++ b/R/optparse.R
@@ -262,10 +262,7 @@ make_option <- function(opt_str, action = NULL, type = NULL, dest = NULL, defaul
         type <- infer_type(action, default)
     }
     if (type == "numeric") type <- "double"
-    # default
-    if ((type != typeof(default)) && !is.null(default)) {
-        storage.mode(default) <- type
-    }
+
     # dest
     if (is.null(dest)) dest <- sub("^--", "", long_flag)
     # metavar


### PR DESCRIPTION
I think this is not necessary, the user should understand their default value type, rather than using the type to convert again, and more importantly, this affects the functionality of the callback, callback is best for raw character processing, but this will make the callback type not consistent with the default value.
for example, I have a callback:
`str2bool <- function(option, flag, option_value, parser) {
  s <- tolower(as.character(option_value))
  if (s %in% c("0", "false", "f", "no", "n")) {
    FALSE
  } else {
    TRUE
  }
}`
It handles strings, and return logical, but if I set a logical default value, it will become character, not logical.